### PR TITLE
🔧 Fix: GitHub Actions runner acquisition issues

### DIFF
--- a/.github/workflows/openlinks-agent.yml
+++ b/.github/workflows/openlinks-agent.yml
@@ -4,6 +4,12 @@ name: OpenLinks Agent
 on:
   issues:
     types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to process'
+        required: true
+        type: number
 
 permissions:
   contents: write
@@ -12,9 +18,10 @@ permissions:
 
 jobs:
   process-request:
-    # Only run if the label is 'openlinks'
-    if: github.event.label.name == 'openlinks'
-    runs-on: ubuntu-latest
+    # Only run if the label is 'openlinks' OR manually triggered
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'openlinks'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
     
     steps:
       - name: Checkout repository
@@ -50,15 +57,40 @@ jobs:
           # Install OpenHands SDK if available (for feature requests)
           pip install "openhands-sdk" || echo "OpenHands SDK not available, feature requests will be limited"
       
+      - name: Get issue details
+        id: issue
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ISSUE_NUM="${{ inputs.issue_number }}"
+          else
+            ISSUE_NUM="${{ github.event.issue.number }}"
+          fi
+          
+          echo "number=$ISSUE_NUM" >> $GITHUB_OUTPUT
+          
+          ISSUE_DATA=$(gh issue view $ISSUE_NUM --json title,body --repo ${{ github.repository }})
+          ISSUE_TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
+          ISSUE_BODY=$(echo "$ISSUE_DATA" | jq -r '.body')
+          
+          echo "title<<EOF" >> $GITHUB_OUTPUT
+          echo "$ISSUE_TITLE" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$ISSUE_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Run OpenLinks Agent
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           LLM_MODEL: ${{ vars.LLM_MODEL || 'claude-sonnet-4-5-20250929' }}
           LLM_BASE_URL: ${{ vars.LLM_BASE_URL || 'https://llm-proxy.app.all-hands.dev/' }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          ISSUE_TITLE: ${{ steps.issue.outputs.title }}
+          ISSUE_BODY: ${{ steps.issue.outputs.body }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           cd "$GITHUB_WORKSPACE"
@@ -68,7 +100,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: openlinks-agent-logs-${{ github.event.issue.number }}
+          name: openlinks-agent-logs-${{ steps.issue.outputs.number }}
           path: |
             *.log
             output/


### PR DESCRIPTION
## 🐛 Problem

GitHub Actions workflows are failing with:
```
The job was not acquired by Runner of type hosted even after multiple attempts
```

All recent workflow runs fail before any steps execute. The jobs get cancelled without running.

---

## 🔍 Root Cause

This is a **GitHub Actions infrastructure issue** where runners aren't picking up jobs. Common causes:
1. Surge in Actions usage across GitHub
2. Configuration issues with `ubuntu-latest`
3. Missing timeout causing abandoned jobs
4. No fallback for manual testing

---

## ✅ Fixes Applied

### 1. **Explicit Runner Version**
```yaml
# Before
runs-on: ubuntu-latest

# After
runs-on: ubuntu-22.04
```
Using a specific version may help with runner allocation.

### 2. **Explicit Timeout**
```yaml
timeout-minutes: 30
```
Prevents jobs from hanging indefinitely if runner is acquired but stalls.

### 3. **Manual Dispatch Fallback**
```yaml
on:
  issues:
    types: [labeled]
  workflow_dispatch:  # NEW!
    inputs:
      issue_number:
        description: 'Issue number to process'
        required: true
        type: number
```

Now you can **manually trigger** the workflow for any issue if automatic triggering fails!

### 4. **Unified Issue Fetching**
Added a dedicated step to fetch issue details that works for both:
- Automatic triggers (issue labeled)
- Manual triggers (workflow_dispatch)

---

## 🧪 Testing

### Test Automatic Trigger
1. Merge this PR
2. Create issue or re-label existing issue #7 or #9
3. Watch workflow run automatically

### Test Manual Trigger
1. Go to Actions tab → OpenLinks Agent → Run workflow
2. Enter issue number (e.g., 7)
3. Click "Run workflow"
4. Watch it process the issue manually

---

## 📊 Changes

```diff
+ workflow_dispatch trigger with issue_number input
+ runs-on: ubuntu-22.04 (explicit version)
+ timeout-minutes: 30
+ Dedicated issue fetching step
+ Works for both automatic and manual triggers
```

---

## 🎯 Benefits

✅ **Fallback option** - Can manually run if auto-trigger fails  
✅ **Better diagnostics** - Explicit timeout helps identify stalls  
✅ **More reliable** - Specific runner version may reduce acquisition failures  
✅ **Flexible** - Can process any issue on demand  

---

## 🚀 Immediate Action

After merging:
1. Try automatic trigger (label an issue)
2. If that still fails, use manual trigger:
   - Actions → OpenLinks Agent → Run workflow → Enter issue #7
3. This will let us diagnose if it's a runner issue or code issue

---

**This gives us a workaround while GitHub resolves runner acquisition issues!** 🛠️