### PR TITLE
Rebuild as Vercel-hosted short-link service with optional Telegram notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,8 @@ If it prints anything else, fix the author (`git commit --amend
 `jamiechicago312/OpenLinks` - a tiny short-link service. Each short
 link is a JSON file under `data/links/active/`, and a single Vercel
 serverless function performs a 307/308 redirect to the configured
-destination. There is intentionally no UI, no admin panel, and no
-tracking layer.
+destination. There is intentionally no UI and no admin panel. Click
+notifications are opt-in via Telegram (see Conventions).
 
 ## Stack
 
@@ -83,13 +83,27 @@ tracking layer.
 
 ## Conventions
 
-- **One short link = one JSON file** in `data/links/active/`. Keep
-  filenames short and stable; the basename (without `.json`) is the
-  public short path.
-- **Never add tracking.** The redirect handler is intentionally
-  side-effect free - no analytics calls, no cookies, no logging of
-  referrer / IP / UA. The `Cache-Control: no-store` header is set on
-  every redirect for that reason.
+- **One short link = one JSON file** in `data/links/active/`. The
+  public short path is the `slug` field inside the file, not the
+  filename - keep both consistent anyway, so anyone browsing the
+  directory can guess the slug without opening the file.
+- **Never add tracking by default.** The redirect handler is
+  side-effect free unless the operator opts in via env vars. No
+  analytics calls, no cookies, no logging of referrer / IP / UA in
+  the default deployment.
+- **Click notifications are opt-in via Telegram.** Setting both
+  `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in the Vercel project's
+  environment variables enables a fire-and-forget POST to the
+  Telegram bot API on every click, with city, country, user agent,
+  and referer. Without both env vars, no notification fires. The
+  notification MUST be fire-and-forget (never `await`, always
+  `.catch(() => {})`) - analytics must never block or fail the
+  redirect.
+- **Use one short link per job application** when tracking
+  application engagement. Name files `app-<company>.json` with the
+  matching `slug` (e.g. `/app-google`). The path itself tells you
+  which application received a click, with no need to disambiguate
+  from referer or other signals.
 - **Path matching is normalized** in `redirects.js` before lookup, so
   a request to `/Foo/` and `/foo` resolve identically.
 - **Status codes are per-link**, not a single global default. Pick 307

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A small, Vercel-hosted short link service.
 
 Each short link lives in its own JSON file under `data/links/active/`.
 A single Vercel serverless function handles redirects. There is no analytics,
-no tracking, and no database — just static JSON files and a 307/308 response.
+no tracking by default, and no database — just static JSON files and a 307/308
+response. Click notifications to a Telegram bot are available as an optional
+opt-in via environment variables (see "Click notifications" below).
 
 ## How it works
 
@@ -81,6 +83,48 @@ to work without you having to bake UTMs into the destination.
 Internal routing parameter (`__oh_redirect_pathname`) is stripped before the
 redirect.
 
+## Click notifications (optional, opt-in)
+
+If you set both of these environment variables in your Vercel project, every
+click will fire-and-forget POST a message to a Telegram bot:
+
+- `TELEGRAM_BOT_TOKEN` — the bot token from `@BotFather`.
+- `TELEGRAM_CHAT_ID` — your numeric chat ID (DM your bot once, then call
+  `https://api.telegram.org/bot<TOKEN>/getUpdates` to find it).
+
+If either is unset, no notification fires and the redirect behaves exactly as
+before. There is no other knob to flip.
+
+The message includes the short path, timestamp, approximate city/country
+(from Vercel's edge geo headers), user agent, and referer. The fetch is
+fired without `await`, so a slow or unreachable Telegram endpoint can never
+delay or fail the redirect.
+
+Set up a bot in 2 minutes:
+
+1. DM `@BotFather`, send `/newbot`, follow the prompts, copy the token.
+2. DM your new bot any message so it can DM you back.
+3. Visit `https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates` and copy the
+   `chat.id` from the response.
+4. In Vercel: Settings → Environment Variables → add `TELEGRAM_BOT_TOKEN`
+   and `TELEGRAM_CHAT_ID`. Redeploy.
+
+## Per-application link pattern
+
+If you're sending these links to recruiters as part of a job search, the
+simplest way to know which company clicked is to give each application its
+own short link. Filename and slug should both reflect the company:
+
+```text
+data/links/active/app-google.json   → /app-google
+data/links/active/app-meta.json     → /app-meta
+data/links/active/app-acme.json     → /app-acme
+```
+
+The path itself is the only signal you need; no need to disambiguate from
+referer or other header data. Combine with Telegram notifications and you get
+a push on your phone each time a recruiter opens a specific application.
+
 ## Local verification
 
 ```bash
@@ -104,9 +148,12 @@ node --check redirects-loader.js
 1. Push this repo to GitHub.
 2. Import it into Vercel as a new project.
 3. (Optional) Set `FALLBACK_DESTINATION` in Vercel environment variables.
-4. Done — every push to `main` redeploys.
+4. (Optional) Set `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` to enable
+   click notifications. See "Click notifications" above.
+5. Done — every push to `main` redeploys.
 
-No build step, no environment secrets, no database.
+No build step, no database. Environment secrets are only needed if you opt
+into Telegram notifications.
 
 ## File layout
 
@@ -117,8 +164,11 @@ No build step, no environment secrets, no database.
 ├── data/
 │   └── links/
 │       └── active/          # One JSON file per short link
+├── lib/
+│   └── telegram.js          # Optional Telegram click-notification module
 ├── test/
-│   └── redirects.test.js    # Unit tests for the redirect logic
+│   ├── redirects.test.js    # Unit tests for the redirect logic
+│   └── telegram.test.js     # Unit tests for the telegram module
 ├── redirects.config.json    # Fallback destination
 ├── redirects.js             # Core redirect logic (lookup, normalize, build URL)
 ├── redirects-loader.js      # Loads link JSON files into an in-memory index
@@ -126,11 +176,6 @@ No build step, no environment secrets, no database.
 ├── package.json
 ├── .gitignore
 ├── LICENSE
+├── AGENTS.md                # Repo-specific agent guardrails
 └── README.md
 ```
-
-## Why no tracking?
-
-This project intentionally has no analytics or tracking integrations. If you
-need click counts, point your own analytics tool at the destination URLs or
-add a tracking layer in front of `api/redirect.js`.

--- a/api/redirect.js
+++ b/api/redirect.js
@@ -4,6 +4,7 @@ const {
   normalizePathname,
 } = require("../redirects");
 const { fallbackDestination, redirectsBySource } = require("../redirects-loader");
+const { notifyClick } = require("../lib/telegram");
 
 const INTERNAL_PATHNAME_QUERY_KEY = "__oh_redirect_pathname";
 
@@ -42,4 +43,13 @@ module.exports = async function handler(req, res) {
   res.setHeader("Location", destinationUrl.toString());
   res.statusCode = redirectDefinition.statusCode;
   res.end();
+
+  notifyClick({
+    shortPath: requestPathname,
+    timestamp: new Date().toISOString(),
+    city: req.headers["x-vercel-ip-city"],
+    country: req.headers["x-vercel-ip-country"],
+    userAgent: req.headers["user-agent"],
+    referer: req.headers["referer"] || req.headers["referrer"],
+  });
 };

--- a/data/links/active/app-example.json
+++ b/data/links/active/app-example.json
@@ -1,0 +1,7 @@
+{
+  "slug": "/app-example",
+  "destination": "https://example.com",
+  "permanent": false,
+  "description": "Placeholder for the per-application short-link pattern. In a real deployment, replace `destination` with the URL recruiters should land on for this application, then rename both the file and the `slug` to match the company (for example `/app-google`, `/app-acme`, `/app-startup-x`). The path name is the only signal you need to know which company clicked.",
+  "tags": ["job-application", "example"]
+}

--- a/lib/telegram.js
+++ b/lib/telegram.js
@@ -1,0 +1,61 @@
+const TELEGRAM_API_BASE = "https://api.telegram.org";
+
+function isTelegramConfigured() {
+  return Boolean(
+    process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_CHAT_ID,
+  );
+}
+
+// Telegram's legacy "Markdown" parse mode treats these characters as
+// formatting markup and will reject the message if they appear unescaped
+// inside a non-entity span. We use legacy Markdown (not MarkdownV2) so we
+// only have to escape these four.
+function escapeMarkdown(text) {
+  return String(text == null ? "" : text).replace(/([_*`[])/g, "\\$1");
+}
+
+function formatClickMessage(click) {
+  const shortPath = escapeMarkdown(click.shortPath);
+  const timestamp = escapeMarkdown(click.timestamp);
+  const city = escapeMarkdown(click.city || "?");
+  const country = escapeMarkdown(click.country || "?");
+  const userAgent = escapeMarkdown(click.userAgent || "?");
+  const referer = escapeMarkdown(click.referer || "(direct)");
+
+  return [
+    `🟢 *${shortPath}* clicked`,
+    "",
+    `*When:* ${timestamp}`,
+    `*Where:* ${city}, ${country}`,
+    `*Device:* ${userAgent}`,
+    `*Referer:* ${referer}`,
+  ].join("\n");
+}
+
+function notifyClick(click) {
+  if (!isTelegramConfigured()) {
+    return;
+  }
+  const url = `${TELEGRAM_API_BASE}/bot${process.env.TELEGRAM_BOT_TOKEN}/sendMessage`;
+  const body = {
+    chat_id: process.env.TELEGRAM_CHAT_ID,
+    text: formatClickMessage(click),
+    parse_mode: "Markdown",
+    disable_web_page_preview: true,
+  };
+
+  // Fire-and-forget: never await, never throw.
+  // Analytics must never block or fail the redirect.
+  fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }).catch(() => {});
+}
+
+module.exports = {
+  escapeMarkdown,
+  formatClickMessage,
+  isTelegramConfigured,
+  notifyClick,
+};

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -1,0 +1,173 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  escapeMarkdown,
+  formatClickMessage,
+  isTelegramConfigured,
+  notifyClick,
+} = require("../lib/telegram");
+
+test("escapeMarkdown escapes Telegram Markdown special characters", () => {
+  assert.equal(escapeMarkdown("hello"), "hello");
+  assert.equal(escapeMarkdown("a_b*c"), "a\\_b\\*c");
+  assert.equal(escapeMarkdown("[link]"), "\\[link]");
+  assert.equal(escapeMarkdown("`code`"), "\\`code\\`");
+});
+
+test("escapeMarkdown handles nullish and non-string input safely", () => {
+  assert.equal(escapeMarkdown(null), "");
+  assert.equal(escapeMarkdown(undefined), "");
+  assert.equal(escapeMarkdown(42), "42");
+});
+
+test("formatClickMessage produces a multi-line Markdown message with all fields", () => {
+  const message = formatClickMessage({
+    shortPath: "/app-google",
+    timestamp: "2026-06-30T15:00:00.000Z",
+    city: "Chicago",
+    country: "US",
+    userAgent: "Mozilla/5.0",
+    referer: "https://mail.google.com/",
+  });
+
+  assert.match(message, /app-google/);
+  assert.match(message, /2026-06-30T15:00:00/);
+  assert.match(message, /Chicago/);
+  assert.match(message, /US/);
+  assert.match(message, /Mozilla/);
+  assert.match(message, /mail\.google\.com/);
+});
+
+test("formatClickMessage falls back to ? and (direct) when fields are missing", () => {
+  const message = formatClickMessage({
+    shortPath: "/foo",
+    timestamp: "2026-01-01T00:00:00.000Z",
+  });
+
+  assert.match(message, /\?/);
+  assert.match(message, /\(direct\)/);
+});
+
+test("isTelegramConfigured reflects env vars at call time", () => {
+  const savedToken = process.env.TELEGRAM_BOT_TOKEN;
+  const savedChat = process.env.TELEGRAM_CHAT_ID;
+
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.TELEGRAM_CHAT_ID;
+  assert.equal(isTelegramConfigured(), false);
+
+  process.env.TELEGRAM_BOT_TOKEN = "token";
+  assert.equal(isTelegramConfigured(), false);
+
+  process.env.TELEGRAM_CHAT_ID = "123";
+  assert.equal(isTelegramConfigured(), true);
+
+  if (savedToken === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
+  else process.env.TELEGRAM_BOT_TOKEN = savedToken;
+  if (savedChat === undefined) delete process.env.TELEGRAM_CHAT_ID;
+  else process.env.TELEGRAM_CHAT_ID = savedChat;
+});
+
+test("notifyClick is a no-op when telegram is not configured", async () => {
+  const savedToken = process.env.TELEGRAM_BOT_TOKEN;
+  const savedChat = process.env.TELEGRAM_CHAT_ID;
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.TELEGRAM_CHAT_ID;
+
+  let fetchCalled = false;
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    fetchCalled = true;
+    return { ok: true };
+  };
+  try {
+    notifyClick({
+      shortPath: "/x",
+      timestamp: "t",
+      city: "c",
+      country: "C",
+      userAgent: "u",
+      referer: "r",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+  } finally {
+    global.fetch = originalFetch;
+    if (savedToken !== undefined) process.env.TELEGRAM_BOT_TOKEN = savedToken;
+    if (savedChat !== undefined) process.env.TELEGRAM_CHAT_ID = savedChat;
+  }
+  assert.equal(fetchCalled, false);
+});
+
+test("notifyClick fires a fire-and-forget fetch when configured", async () => {
+  const savedToken = process.env.TELEGRAM_BOT_TOKEN;
+  const savedChat = process.env.TELEGRAM_CHAT_ID;
+  process.env.TELEGRAM_BOT_TOKEN = "test-token";
+  process.env.TELEGRAM_CHAT_ID = "12345";
+
+  let captured = null;
+  const originalFetch = global.fetch;
+  global.fetch = async (url, options) => {
+    captured = { url, options };
+    return { ok: true, status: 200 };
+  };
+  try {
+    notifyClick({
+      shortPath: "/app-google",
+      timestamp: "2026-06-30T15:00:00.000Z",
+      city: "Chicago",
+      country: "US",
+      userAgent: "Mozilla/5.0",
+      referer: "https://mail.google.com/",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+  } finally {
+    global.fetch = originalFetch;
+    if (savedToken === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
+    else process.env.TELEGRAM_BOT_TOKEN = savedToken;
+    if (savedChat === undefined) delete process.env.TELEGRAM_CHAT_ID;
+    else process.env.TELEGRAM_CHAT_ID = savedChat;
+  }
+
+  assert.ok(captured, "fetch was called");
+  assert.match(
+    captured.url,
+    /api\.telegram\.org\/bottest-token\/sendMessage/,
+  );
+  const body = JSON.parse(captured.options.body);
+  assert.equal(body.chat_id, "12345");
+  assert.equal(body.parse_mode, "Markdown");
+  assert.equal(body.disable_web_page_preview, true);
+  assert.match(body.text, /app-google/);
+  assert.match(body.text, /Chicago/);
+});
+
+test("notifyClick swallows fetch errors silently", async () => {
+  const savedToken = process.env.TELEGRAM_BOT_TOKEN;
+  const savedChat = process.env.TELEGRAM_CHAT_ID;
+  process.env.TELEGRAM_BOT_TOKEN = "test-token";
+  process.env.TELEGRAM_CHAT_ID = "12345";
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    throw new Error("network down");
+  };
+  try {
+    notifyClick({
+      shortPath: "/x",
+      timestamp: "t",
+      city: "c",
+      country: "C",
+      userAgent: "u",
+      referer: "r",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+  } finally {
+    global.fetch = originalFetch;
+    if (savedToken === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
+    else process.env.TELEGRAM_BOT_TOKEN = savedToken;
+    if (savedChat === undefined) delete process.env.TELEGRAM_CHAT_ID;
+    else process.env.TELEGRAM_CHAT_ID = savedChat;
+  }
+  // Reaching here without an unhandled rejection is the assertion.
+});


### PR DESCRIPTION
Rebuilds OpenLinks as a small Vercel-hosted short-link service and adds an opt-in Telegram click-notification path. Drops the Python agent stack, LLM-driven workflows, the natural-language issue template, and the tracking layer; replaces it with one serverless function backed by JSON files.

This replaces the earlier draft PR (#14) which targeted `feat/vercel-short-links`; that intermediate branch is no longer needed.

## Three commits

- **`9f314fc`** — Replace agent stack with a Vercel-hosted short-link service. Each short link is a JSON file under `data/links/active/`, and a single serverless function performs the 307/308 redirect.
- **`d78b5a6`** — Add AGENTS.md with the Vercel Hobby author-identity guard.
- **`e73410c`** — Add optional Telegram click notifications (opt-in via `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` env vars).

## What you get

- `redirects.js`: lookup, normalization, URL building (pure functions)
- `redirects-loader.js`: reads `data/links/active/*.json` at cold start
- `redirects.config.json`: fallback destination (overridable via `FALLBACK_DESTINATION`)
- `api/redirect.js`: Vercel handler, side-effect-free by default
- `lib/telegram.js`: opt-in fire-and-forget Telegram click notifications
- `vercel.json`: routes non-file paths to the handler
- 16 unit tests via `node --test` (8 redirect logic + 8 telegram)
- `AGENTS.md`: Vercel Hobby author-identity rule + per-application link pattern

## Click notifications (opt-in)

When both `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` are set in the Vercel project's environment variables, every click fires a fire-and-forget POST to the Telegram bot API with short path, timestamp, city/country (from Vercel edge geo headers), user agent, and referer. Without both env vars, no notification fires and the redirect behaves exactly as before.

```
🟢 /app-google clicked

*When:* 2026-06-30T15:00:00.000Z
*Where:* Chicago, US
*Device:* Mozilla/5.0 ...
*Referer:* https://mail.google.com/
```

The fetch happens after `res.end()`, without `await`, with errors swallowed. A slow or unreachable Telegram endpoint can never delay or fail the redirect.

## Per-application link pattern

For job-search tracking, name files `app-<company>.json` with matching `slug` (e.g. `/app-google`). The path itself tells you which application received a click — no need to disambiguate from referer or other signals.

## Test plan

- [x] `npm test` — 16/16 pass (8 existing redirect tests + 8 new telegram tests)
- [ ] Manual: deploy preview, confirm redirects work without env vars set
- [ ] Manual: deploy preview with `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` set, hit any short link, confirm Telegram DM arrives

Opened as draft per the AGENTS.md "never merge yourself, hand to Jamie" rule.